### PR TITLE
chore: creates and uses the non-privileged user iris in EPS Docker files

### DIFF
--- a/.scripts/entrypoint-eps.sh
+++ b/.scripts/entrypoint-eps.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+chown -R iris:iris ./settings
+
+exec su iris -c "./eps $*"

--- a/.scripts/entrypoint-eps.sh
+++ b/.scripts/entrypoint-eps.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
-chown -R iris:iris ./settings
+if ! su iris -c "find ./settings -type f -exec cat {} > /dev/null +"; then
+    chown -R iris:iris ./settings
+fi
 
 exec su iris -c "./eps $*"

--- a/.scripts/entrypoint-proxy.sh
+++ b/.scripts/entrypoint-proxy.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
-chown -R iris:iris ./settings
+if ! su iris -c "find ./settings -type f -exec cat {} > /dev/null +"; then
+    chown -R iris:iris ./settings
+fi
 
 exec su iris -c "./proxy $*"

--- a/.scripts/entrypoint-proxy.sh
+++ b/.scripts/entrypoint-proxy.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+chown -R iris:iris ./settings
+
+exec su iris -c "./proxy $*"

--- a/.scripts/entrypoint-sd.sh
+++ b/.scripts/entrypoint-sd.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+chown -R iris:iris ./settings
+
+exec su iris -c "./sd $*"

--- a/.scripts/entrypoint-sd.sh
+++ b/.scripts/entrypoint-sd.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
-chown -R iris:iris ./settings
+if ! su iris -c "find ./settings -type f -exec cat {} > /dev/null +"; then
+    chown -R iris:iris ./settings
+fi
 
 exec su iris -c "./sd $*"

--- a/docker/Eps.dockerfile
+++ b/docker/Eps.dockerfile
@@ -14,6 +14,11 @@ COPY . .
 RUN make
 
 FROM alpine:latest
+
+# Create a group and user
+RUN addgroup --gid 9999 iris && adduser --disabled-password --gecos '' --uid 9999 -G iris -s /bin/ash iris
+
 WORKDIR /app
-COPY --from=builder /go/bin/eps /app/eps
-ENTRYPOINT ["./eps"]
+COPY --from=builder /go/bin/eps /app/.scripts/entrypoint-eps.sh /app/
+
+ENTRYPOINT ["/bin/sh", "./entrypoint-eps.sh"]

--- a/docker/InternalServer.dockerfile
+++ b/docker/InternalServer.dockerfile
@@ -14,6 +14,12 @@ COPY . .
 RUN make examples
 
 FROM alpine:latest
+
+# Create a group and user
+RUN addgroup --gid 9999 iris && adduser --disabled-password --gecos '' --uid 9999 -G iris -s /bin/ash iris
+# Change to non-root privilege
+USER iris:iris
+
 WORKDIR /app
 COPY --from=builder /go/bin/internal-server /app/internal-server
 ENTRYPOINT ["./internal-server"]

--- a/docker/Proxy.dockerfile
+++ b/docker/Proxy.dockerfile
@@ -14,6 +14,11 @@ COPY . .
 RUN make
 
 FROM alpine:latest
+
+# Create a group and user
+RUN addgroup --gid 9999 iris && adduser --disabled-password --gecos '' --uid 9999 -G iris -s /bin/ash iris
+
 WORKDIR /app
-COPY --from=builder /go/bin/proxy /app/proxy
-ENTRYPOINT ["./proxy"]
+COPY --from=builder /go/bin/proxy /app/.scripts/entrypoint-proxy.sh /app/
+
+ENTRYPOINT ["/bin/sh", "./entrypoint-proxy.sh"]

--- a/docker/Scripts.dockerfile
+++ b/docker/Scripts.dockerfile
@@ -4,6 +4,7 @@ RUN apk add --update bash
 RUN apk add --update coreutils && rm -rf /var/cache/apk/*
 RUN bash --version
 RUN bash
+
 WORKDIR /app
 COPY . .
 ENTRYPOINT [ "make" ]

--- a/docker/Sd.dockerfile
+++ b/docker/Sd.dockerfile
@@ -14,6 +14,11 @@ COPY . .
 RUN make
 
 FROM alpine:latest
+
+# Create a group and user
+RUN addgroup --gid 9999 iris && adduser --disabled-password --gecos '' --uid 9999 -G iris -s /bin/ash iris
+
 WORKDIR /app
-COPY --from=builder /go/bin/sd /app/sd
-ENTRYPOINT ["./sd"]
+COPY --from=builder /go/bin/sd /app/.scripts/entrypoint-sd.sh /app/
+
+ENTRYPOINT ["/bin/sh", "./entrypoint-sd.sh"]


### PR DESCRIPTION
The applications are started in the container by a script under the user
iris. Still as root, all directories and files under settings/ are
assigned to this user beforehand so that the applications can use all
files.

Refs iris-connect/iris-backlog#224