### PR TITLE
fix: avoid readable but not writeable files

### DIFF
--- a/.scripts/entrypoint-eps.sh
+++ b/.scripts/entrypoint-eps.sh
@@ -3,10 +3,14 @@
 if [[ -z "${MOUNT_POINTS}" ]]
 then
     echo "The environment variable MOUNT_POINTS can be set to a comma separated list of the mount points in the container. Use default now."
-    MOUNT_POINTS="/config,/tls,/app/settings"
+    READ_MOUNT_POINTS="/config,/tls,/app/settings"
+    WRITE_MOUNT_POINTS=""
+    MOUNT_POINTS=$READ_MOUNT_POINTS,$WRITE_MOUNT_POINTS
 fi
 
 echo "MOUNT_POINTS is set to \"${MOUNT_POINTS}\""
+echo "READ_MOUNT_POINTS is set to \"${READ_MOUNT_POINTS}\""
+echo "WRITE_MOUNT_POINTS is set to \"${WRITE_MOUNT_POINTS}\""
 
 for point in ${MOUNT_POINTS//,/ }
 do
@@ -16,13 +20,22 @@ do
         continue
     fi
 
-    if ! su iris -c "find ${point} -type f -exec cat {} > /dev/null +"
+    echo "chown is made for \"${point}\""
+    chown -R iris:iris ${point}
+    
+    echo "chmod u+r is made for \"${point}\""
+    chmod -R u+r ${point}
+done
+
+for point in ${WRITE_MOUNT_POINTS//,/ }
+do
+    if [ ! -d ${point} ]
     then
-        echo "chown is made for \"${point}\""
-        chown -R iris:iris ${point}
-    else
-        echo "Skip readable directory: \"${point}\""
+        continue
     fi
+    
+    echo "chmod u+w is made for \"${point}\""
+    chmod -R u+w ${point}
 done
 
 echo "Execute eps with user iris"

--- a/.scripts/entrypoint-proxy.sh
+++ b/.scripts/entrypoint-proxy.sh
@@ -3,10 +3,14 @@
 if [[ -z "${MOUNT_POINTS}" ]]
 then
     echo "The environment variable MOUNT_POINTS can be set to a comma separated list of the mount points in the container. Use default now."
-    MOUNT_POINTS="/config,/tls,/app/settings,/storage,/app/db,/tmp"
+    READ_MOUNT_POINTS="/config,/tls,/app/settings"
+    WRITE_MOUNT_POINTS="/storage,/app/db,/tmp"
+    MOUNT_POINTS=$READ_MOUNT_POINTS,$WRITE_MOUNT_POINTS
 fi
 
 echo "MOUNT_POINTS is set to \"${MOUNT_POINTS}\""
+echo "READ_MOUNT_POINTS is set to \"${READ_MOUNT_POINTS}\""
+echo "WRITE_MOUNT_POINTS is set to \"${WRITE_MOUNT_POINTS}\""
 
 for point in ${MOUNT_POINTS//,/ }
 do
@@ -16,13 +20,22 @@ do
         continue
     fi
 
-    if ! su iris -c "find ${point} -type f -exec cat {} > /dev/null +"
+    echo "chown is made for \"${point}\""
+    chown -R iris:iris ${point}
+    
+    echo "chmod u+r is made for \"${point}\""
+    chmod -R u+r ${point}
+done
+
+for point in ${WRITE_MOUNT_POINTS//,/ }
+do
+    if [ ! -d ${point} ]
     then
-        echo "chown is made for \"${point}\""
-        chown -R iris:iris ${point}
-    else
-        echo "Skip readable directory: \"${point}\""
+        continue
     fi
+    
+    echo "chmod u+w is made for \"${point}\""
+    chmod -R u+w ${point}
 done
 
 echo "Execute proxy with user iris"

--- a/.scripts/entrypoint-sd.sh
+++ b/.scripts/entrypoint-sd.sh
@@ -3,10 +3,14 @@
 if [[ -z "${MOUNT_POINTS}" ]]
 then
     echo "The environment variable MOUNT_POINTS can be set to a comma separated list of the mount points in the container. Use default now."
-    MOUNT_POINTS="/config,/tls,/app/settings,/storage,/app/db,/tmp"
+    READ_MOUNT_POINTS="/config,/tls,/app/settings"
+    WRITE_MOUNT_POINTS="/storage,/app/db,/tmp"
+    MOUNT_POINTS=$READ_MOUNT_POINTS,$WRITE_MOUNT_POINTS
 fi
 
 echo "MOUNT_POINTS is set to \"${MOUNT_POINTS}\""
+echo "READ_MOUNT_POINTS is set to \"${READ_MOUNT_POINTS}\""
+echo "WRITE_MOUNT_POINTS is set to \"${WRITE_MOUNT_POINTS}\""
 
 for point in ${MOUNT_POINTS//,/ }
 do
@@ -16,13 +20,22 @@ do
         continue
     fi
 
-    if ! su iris -c "find ${point} -type f -exec cat {} > /dev/null +"
+    echo "chown is made for \"${point}\""
+    chown -R iris:iris ${point}
+    
+    echo "chmod u+r is made for \"${point}\""
+    chmod -R u+r ${point}
+done
+
+for point in ${WRITE_MOUNT_POINTS//,/ }
+do
+    if [ ! -d ${point} ]
     then
-        echo "chown is made for \"${point}\""
-        chown -R iris:iris ${point}
-    else
-        echo "Skip readable directory: \"${point}\""
+        continue
     fi
+    
+    echo "chmod u+w is made for \"${point}\""
+    chmod -R u+w ${point}
 done
 
 echo "Execute sd with user iris"


### PR DESCRIPTION
It has happened that old announcements.db files, created as root, are now readable and not writable. This previously caused that their owner is not changed, but they also can not be opened and written.

As a solution, the option to bypass the user change with suitable rights is dropped. The owner is always changed. In addition, read and write permissions are given to the owner for safety.