### PR TITLE
DCT for docker images

### DIFF
--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -21,7 +21,7 @@ jobs:
           echo $VERSION
           echo ${{ env.VERSION }}
       - name: Build and push eps
-        uses: docker/build-push-action@v1
+        uses: docker/build-push-action@v2.9.0
         with:
           build_args: VERSION=${{ env.VERSION }}
           username: ${{ secrets.DOCKER_HUB_USER }}
@@ -29,6 +29,15 @@ jobs:
           repository: inoeg/eps
           tag_with_ref: true
           dockerfile: ./docker/Eps.dockerfile
+          push: false
+          load: true
+      - name: Sign and push docker image
+        uses: sudo-bot/action-docker-sign@latest
+        with:
+          image-ref: 'inoeg/eps:${{ env.VERSION }}'
+          private-key-id: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY_IDENTIFIER }}
+          private-key: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY }}
+          private-key-passphrase: ${{ secrets.DOCKER_HUB_DCT_PASSPHRASE }}
       - name: Build and push sd
         uses: docker/build-push-action@v1
         with:

--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -20,11 +20,6 @@ jobs:
         run: |
           echo $VERSION
           echo ${{ env.VERSION }}
-      - name: Create image tag
-        id: meta_eps
-        uses: docker/metadata-action@v3
-        with:
-          images: inoeg/eps
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -32,7 +27,12 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_PW }}
 
-      - name: Build and push eps
+      - name: Create eps image tag
+        id: meta_eps
+        uses: docker/metadata-action@v3
+        with:
+          images: inoeg/eps
+      - name: Build eps
         uses: docker/build-push-action@v2.9.0
         with:
           build-args: VERSION=${{ env.VERSION }}
@@ -41,29 +41,57 @@ jobs:
           push: false
           load: true
           labels: |
-            iris.client-eps.image.revision=${{ github.sha }}
+            iris.eps.image.revision=${{ github.sha }}
       - name: Sign and push docker image
         uses: sudo-bot/action-docker-sign@latest
         with:
-          image-ref: 'inoeg/eps:${{ env.VERSION }}'
+          image-ref: ${{steps.meta_eps.outputs.tags}}
           private-key-id: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY_IDENTIFIER }}
           private-key: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY }}
           private-key-passphrase: ${{ secrets.DOCKER_HUB_DCT_PASSPHRASE }}
-      - name: Build and push sd
-        uses: docker/build-push-action@v1
+
+      - name: Create sd image tag
+        id: meta_sd
+        uses: docker/metadata-action@v3
         with:
-          build_args: VERSION=${{ env.VERSION }}
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_PW }}        
-          repository: inoeg/sd
-          tag_with_ref: true
-          dockerfile: ./docker/Sd.dockerfile
-      - name: Build and push proxy
-        uses: docker/build-push-action@v1
+          images: inoeg/sd
+      - name: Build sd
+        uses: docker/build-push-action@v2.9.0
         with:
-          build_args: VERSION=${{ env.VERSION }}
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_PW }}        
-          repository: inoeg/proxy
-          tag_with_ref: true
-          dockerfile: ./docker/Proxy.dockerfile
+          build-args: VERSION=${{ env.VERSION }}
+          file: ./docker/Sd.dockerfile
+          tags: ${{ steps.meta_sd.outputs.tags }}
+          push: false
+          load: true
+          labels: |
+            iris.sd.image.revision=${{ github.sha }}
+      - name: Sign and push sd image
+        uses: sudo-bot/action-docker-sign@latest
+        with:
+          image-ref: ${{steps.meta_sd.outputs.tags}}
+          private-key-id: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY_IDENTIFIER }}
+          private-key: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY }}
+          private-key-passphrase: ${{ secrets.DOCKER_HUB_DCT_PASSPHRASE }}
+
+      - name: Create proxy image tag
+        id: meta_proxy
+        uses: docker/metadata-action@v3
+        with:
+          images: inoeg/proxy
+      - name: Build proxy
+        uses: docker/build-push-action@v2.9.0
+        with:
+          build-args: VERSION=${{ env.VERSION }}
+          file: ./docker/Proxy.dockerfile
+          tags: ${{ steps.meta_proxy.outputs.tags }}
+          push: false
+          load: true
+          labels: |
+            iris.proxy.image.revision=${{ github.sha }}
+      - name: Sign and push proxy image
+        uses: sudo-bot/action-docker-sign@latest
+        with:
+          image-ref: ${{steps.meta_proxy.outputs.tags}}
+          private-key-id: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY_IDENTIFIER }}
+          private-key: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY }}
+          private-key-passphrase: ${{ secrets.DOCKER_HUB_DCT_PASSPHRASE }}

--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -20,17 +20,22 @@ jobs:
         run: |
           echo $VERSION
           echo ${{ env.VERSION }}
+      - name: Create image tag
+        id: meta_eps
+        uses: docker/metadata-action@v3
+        with:
+          images: inoeg/eps
       - name: Build and push eps
         uses: docker/build-push-action@v2.9.0
         with:
-          build_args: VERSION=${{ env.VERSION }}
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_PW }}        
-          repository: inoeg/eps
-          tag_with_ref: true
-          dockerfile: ./docker/Eps.dockerfile
+          build-args: VERSION=${{ env.VERSION }}
+          context: ./docker/
+          file: Eps.dockerfile
+          tags: ${{ steps.meta_eps.outputs.tags }}
           push: false
           load: true
+          labels: |
+            iris.client-eps.image.revision=${{ github.sha }}
       - name: Sign and push docker image
         uses: sudo-bot/action-docker-sign@latest
         with:

--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           build-args: VERSION=${{ env.VERSION }}
           context: ./docker/
-          file: Eps.dockerfile
+          file: {context}/Eps.dockerfile
           tags: ${{ steps.meta_eps.outputs.tags }}
           push: false
           load: true

--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -25,6 +25,13 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: inoeg/eps
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_PW }}
+
       - name: Build and push eps
         uses: docker/build-push-action@v2.9.0
         with:

--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -29,8 +29,7 @@ jobs:
         uses: docker/build-push-action@v2.9.0
         with:
           build-args: VERSION=${{ env.VERSION }}
-          context: ./docker/
-          file: {context}/Eps.dockerfile
+          file: ./docker/Eps.dockerfile
           tags: ${{ steps.meta_eps.outputs.tags }}
           push: false
           load: true

--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Sign and push versioned eps image
         uses: sudo-bot/action-docker-sign@latest
         with:
-          image-ref: ${{steps.meta_eps.outputs.tags[0]}}
+          image-ref: ${{fromJSON(steps.meta.outputs.json).tags[0]}}
           private-key-id: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY_IDENTIFIER }}
           private-key: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY }}
           private-key-passphrase: ${{ secrets.DOCKER_HUB_DCT_PASSPHRASE }}

--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Sign and push latest eps image
         uses: sudo-bot/action-docker-sign@latest
         with:
-          image-ref: ${{steps.meta_eps.outputs.tags[1]}}
+          image-ref: ${{fromJSON(steps.meta_eps.outputs.json).tags[1]}}
           private-key-id: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY_IDENTIFIER }}
           private-key: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY }}
           private-key-passphrase: ${{ secrets.DOCKER_HUB_DCT_PASSPHRASE }}
@@ -72,10 +72,17 @@ jobs:
           load: true
           labels: |
             iris.sd.image.revision=${{ github.sha }}
-      - name: Sign and push sd image
+      - name: Sign and push sd versioned image
         uses: sudo-bot/action-docker-sign@latest
         with:
-          image-ref: ${{steps.meta_sd.outputs.tags}}
+          image-ref: ${{fromJSON(steps.meta_sd.outputs.json).tags[0]}}
+          private-key-id: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY_IDENTIFIER }}
+          private-key: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY }}
+          private-key-passphrase: ${{ secrets.DOCKER_HUB_DCT_PASSPHRASE }}
+      - name: Sign and push sd latest image
+        uses: sudo-bot/action-docker-sign@latest
+        with:
+          image-ref: ${{fromJSON(steps.meta_sd.outputs.json).tags[1]}}
           private-key-id: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY_IDENTIFIER }}
           private-key: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY }}
           private-key-passphrase: ${{ secrets.DOCKER_HUB_DCT_PASSPHRASE }}
@@ -95,10 +102,17 @@ jobs:
           load: true
           labels: |
             iris.proxy.image.revision=${{ github.sha }}
-      - name: Sign and push proxy image
+      - name: Sign and push proxy versioned image
         uses: sudo-bot/action-docker-sign@latest
         with:
-          image-ref: ${{steps.meta_proxy.outputs.tags}}
+          image-ref: ${{fromJSON(steps.meta_proxy.outputs.json).tags[0]}}
+          private-key-id: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY_IDENTIFIER }}
+          private-key: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY }}
+          private-key-passphrase: ${{ secrets.DOCKER_HUB_DCT_PASSPHRASE }}
+      - name: Sign and push proxy latest image
+        uses: sudo-bot/action-docker-sign@latest
+        with:
+          image-ref: ${{fromJSON(steps.meta_proxy.outputs.json).tags[1]}}
           private-key-id: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY_IDENTIFIER }}
           private-key: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY }}
           private-key-passphrase: ${{ secrets.DOCKER_HUB_DCT_PASSPHRASE }}

--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Sign and push versioned eps image
         uses: sudo-bot/action-docker-sign@latest
         with:
-          image-ref: ${{fromJSON(steps.meta.outputs.json).tags[0]}}
+          image-ref: ${{fromJSON(steps.meta_eps.outputs.json).tags[0]}}
           private-key-id: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY_IDENTIFIER }}
           private-key: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY }}
           private-key-passphrase: ${{ secrets.DOCKER_HUB_DCT_PASSPHRASE }}

--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -42,10 +42,17 @@ jobs:
           load: true
           labels: |
             iris.eps.image.revision=${{ github.sha }}
-      - name: Sign and push docker image
+      - name: Sign and push versioned eps image
         uses: sudo-bot/action-docker-sign@latest
         with:
-          image-ref: ${{steps.meta_eps.outputs.tags}}
+          image-ref: ${{steps.meta_eps.outputs.tags[0]}}
+          private-key-id: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY_IDENTIFIER }}
+          private-key: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY }}
+          private-key-passphrase: ${{ secrets.DOCKER_HUB_DCT_PASSPHRASE }}
+      - name: Sign and push latest eps image
+        uses: sudo-bot/action-docker-sign@latest
+        with:
+          image-ref: ${{steps.meta_eps.outputs.tags[1]}}
           private-key-id: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY_IDENTIFIER }}
           private-key: ${{ secrets.DOCKER_HUB_DCT_PRIVATE_KEY }}
           private-key-passphrase: ${{ secrets.DOCKER_HUB_DCT_PASSPHRASE }}


### PR DESCRIPTION
Updates github workflows.

- uses newer docker/build-push-action@v2.9.0
- signs docker images with inoeg keys to enabled docker content trust (DCT)